### PR TITLE
Fix Vite entry path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/js/app.jsx', 'resources/css/app.css'],
+            input: ['resources/js/App.jsx', 'resources/css/app.css'],
             refresh: true,
         }),
         react(),


### PR DESCRIPTION
## Summary
- update vite entry path to `resources/js/App.jsx`

## Testing
- `npm run build` *(fails: Could not resolve "./pages/admin/Dashboard" from "resources/js/App.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_68486c6cb8288326992d2300936fba95