### PR TITLE
Remove unused navigation imports

### DIFF
--- a/resources/js/App.jsx
+++ b/resources/js/App.jsx
@@ -1,6 +1,6 @@
 // import './bootstrap';
 import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 // import { useAuth } from './contexts/AuthContext'
 import Layout from './components/Layout';
 import HomePage from './pages/HomePage';

--- a/resources/js/pages/BookingPage.jsx
+++ b/resources/js/pages/BookingPage.jsx
@@ -6,11 +6,9 @@ import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
 import axios from 'axios';
 import { useAuth } from './contexts/AuthContext';
-import { useNavigate } from 'react-router-dom';
 
 const BookingPage = () => {
     const { user } = useAuth();
-    const navigate = useNavigate();
     const [selectedDate, setSelectedDate] = useState(new Date());
     const [selectedService, setSelectedService] = useState(null);
     const [selectedSlot, setSelectedSlot] = useState(null);


### PR DESCRIPTION
## Summary
- clean up routing code by dropping unused imports

## Testing
- `npm run build` *(fails: Could not resolve entry module "resources/js/app.jsx")*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684894e9e1308326be864bd3e320e4de