### PR TITLE
Import HttpStatusCodes in AuthController

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -6,6 +6,7 @@ use App\Models\Customer;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Kreait\Laravel\Firebase\Facades\Firebase;
+use App\Constants\HttpStatusCodes;
 
 class AuthController extends BaseController
 {


### PR DESCRIPTION
## Summary
- import HttpStatusCodes so AuthController can reference UNAUTHORIZED status
- ensure invalid token errors return proper HTTP status

## Testing
- `php -l app/Http/Controllers/Api/AuthController.php`
- `./vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68921d0537c083268782a7a4c3fbc4b5