### PR TITLE
Validate firebase UID when canceling appointment

### DIFF
--- a/app/Http/Controllers/Api/AppointmentController.php
+++ b/app/Http/Controllers/Api/AppointmentController.php
@@ -128,14 +128,22 @@ class AppointmentController extends BaseController
 
     public function cancel($id, Request $request): JsonResponse
     {
+        $request->validate([
+            'firebase_uid' => 'required|string',
+        ]);
+
         $appointment = Appointment::find($id);
-        
+
         if (!$appointment) {
             return $this->sendError('Appointment not found', [], HttpStatusCodes::NOT_FOUND);
         }
 
         $customer = Customer::where('firebase_uid', $request->firebase_uid)->first();
-        
+
+        if (!$customer) {
+            return $this->sendError('Customer not found', [], HttpStatusCodes::NOT_FOUND);
+        }
+
         if ($appointment->customer_id !== $customer->id) {
             return $this->sendError('Unauthorized', [], HttpStatusCodes::FORBIDDEN);
         }


### PR DESCRIPTION
## Summary
- validate `firebase_uid` on appointment cancellation
- return 404 if customer for UID is not found before authorization check

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= vendor/bin/phpunit` *(fails: 500 response)*

------
https://chatgpt.com/codex/tasks/task_e_68921dd1a3448326881d968337d06c81