### PR TITLE
Detect encompassing appointment overlaps

### DIFF
--- a/app/Http/Controllers/Api/AppointmentController.php
+++ b/app/Http/Controllers/Api/AppointmentController.php
@@ -50,7 +50,11 @@ class AppointmentController extends BaseController
             $isBooked = Appointment::where('status', '!=', 'canceled')
                 ->where(function ($query) use ($startAt, $endAt) {
                     $query->whereBetween('start_at', [$startAt, $endAt])
-                        ->orWhereBetween('end_at', [$startAt, $endAt]);
+                        ->orWhereBetween('end_at', [$startAt, $endAt])
+                        ->orWhere(function ($query) use ($startAt, $endAt) {
+                            $query->where('start_at', '<', $startAt)
+                                  ->where('end_at', '>', $endAt);
+                        });
                 })
                 ->exists();
 


### PR DESCRIPTION
## Summary
- Ensure appointment availability checks include appointments that start before and end after the requested time

## Testing
- `php -l app/Http/Controllers/Api/AppointmentController.php`
- `mise exec php@8.3 -- ./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68921ec4de6c8326bc7a934c0ed00c10