### PR TITLE
Validate Square webhook payload

### DIFF
--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -31,7 +31,7 @@ class WebhookController extends Controller
 
         $data = json_decode($body, true);
 
-        if (!isset($data['type'])) {
+        if (!is_array($data) || !isset($data['type'], $data['data'])) {
             return response()->json([
                 'success' => false,
                 'message' => 'Invalid webhook payload'


### PR DESCRIPTION
## Summary
- ensure Square webhook payload is valid before dispatching events

## Testing
- `phpunit` *(fails: command not found)*
- `composer install --ignore-platform-req=ext-sodium` *(fails: requires PHP ~8.1–8.3, current 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_68921efeb3d08326a3b650487c1b3124