### PR TITLE
Check appointment customer before notifying in Square webhook

### DIFF
--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -74,7 +74,14 @@ class WebhookController extends Controller
                 'amount_paid_cents' => $data['object']['payment']['amount_money']['amount'] ?? 0,
             ]);
 
-            $appointment->customer->notify(new PaymentReceived($appointment));
+            if ($appointment->customer) {
+                $appointment->customer->notify(new PaymentReceived($appointment));
+            } else {
+                Log::warning('No customer associated with appointment for Square payment', [
+                    'order_id' => $orderId,
+                    'payment_id' => $paymentId,
+                ]);
+            }
         } else {
             Log::warning('Appointment not found for Square payment', [
                 'order_id' => $orderId,


### PR DESCRIPTION
## Summary
- Guard against missing customer when processing Square payments
- Log a warning if a payment webhook references an appointment without a customer

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: missing ext-sodium)*
- `composer install --ignore-platform-req=ext-sodium` *(fails: PHP version requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68921eff07b883268f1a9ebccaa56987