### PR TITLE
feat: add device token registration

### DIFF
--- a/app/Http/Controllers/Api/DeviceTokenController.php
+++ b/app/Http/Controllers/Api/DeviceTokenController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Models\Customer;
+use App\Models\DeviceToken;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use App\Constants\HttpStatusCodes;
+
+class DeviceTokenController extends BaseController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'firebase_uid' => 'required|string',
+            'token' => 'required|string',
+            'platform' => 'required|string',
+        ]);
+
+        $customer = Customer::where('firebase_uid', $request->firebase_uid)->first();
+
+        if (!$customer) {
+            return $this->sendError('Customer not found', [], HttpStatusCodes::NOT_FOUND);
+        }
+
+        DeviceToken::updateOrCreate(
+            ['token' => $request->token],
+            [
+                'customer_id' => $customer->id,
+                'platform' => $request->platform,
+            ]
+        );
+
+        return $this->sendResponse([], 'Device token saved successfully');
+    }
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -23,6 +23,11 @@ class Customer extends Model
         return $this->hasMany(Appointment::class);
     }
 
+    public function deviceTokens(): HasMany
+    {
+        return $this->hasMany(DeviceToken::class);
+    }
+
     /**
      * Route notifications for the mail channel.
      */

--- a/app/Models/DeviceToken.php
+++ b/app/Models/DeviceToken.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DeviceToken extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'customer_id',
+        'token',
+        'platform',
+    ];
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+}

--- a/database/migrations/2025_06_29_222200_create_device_tokens_table.php
+++ b/database/migrations/2025_06_29_222200_create_device_tokens_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('device_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->string('token')->unique();
+            $table->string('platform');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('device_tokens');
+    }
+};

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,14 @@
+importScripts('https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/9.23.0/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+    apiKey: 'placeholder',
+    authDomain: 'placeholder',
+    projectId: 'placeholder',
+    storageBucket: 'placeholder',
+    messagingSenderId: 'placeholder',
+    appId: 'placeholder',
+});
+
+firebase.messaging();
+

--- a/resources/js/index.jsx
+++ b/resources/js/index.jsx
@@ -4,6 +4,8 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import App from './app';
+import { auth, isFirebaseConfigured, requestNotificationPermission } from './firebase';
+import { apiCall } from './utils/api';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
@@ -17,3 +19,29 @@ root.render(
         </BrowserRouter>
     </React.StrictMode>
 );
+
+if (isFirebaseConfigured && 'serviceWorker' in navigator) {
+    auth.onAuthStateChanged((user) => {
+        if (user) {
+            navigator.serviceWorker.register('/firebase-messaging-sw.js')
+                .then(async (registration) => {
+                    const token = await requestNotificationPermission(registration);
+                    if (token) {
+                        try {
+                            await apiCall('/api/device-tokens', {
+                                method: 'POST',
+                                body: JSON.stringify({
+                                    firebase_uid: user.uid,
+                                    token,
+                                    platform: 'web',
+                                }),
+                            });
+                        } catch (error) {
+                            console.error('Failed to store device token', error);
+                        }
+                    }
+                })
+                .catch((error) => console.error('Service worker registration failed', error));
+        }
+    });
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ServiceTypeController;
 use App\Http\Controllers\Api\AvailabilityController;
 use App\Http\Controllers\Api\AppointmentController;
+use App\Http\Controllers\Api\DeviceTokenController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\ClientController;
 use App\Http\Controllers\Api\Admin\BlockedDatesController;
@@ -36,6 +37,7 @@ Route::middleware(['auth.firebase'])->group(function () {
     Route::post('/appointments', [AppointmentController::class, 'store']);
     Route::get('/appointments/{id}', [AppointmentController::class, 'show']);
     Route::post('/appointments/{id}/cancel', [AppointmentController::class, 'cancel']);
+    Route::post('/device-tokens', [DeviceTokenController::class, 'store']);
 });
 
 // Admin routes


### PR DESCRIPTION
## Summary
- add device token model and migration
- create API endpoint for saving device tokens
- set up Firebase messaging on frontend

## Testing
- `php artisan test` *(fails: vendor autoload missing)*
- `composer install` *(fails: lcobucci/jwt 5.3.0 requires ext-sodium)*
- `npm run build` *(fails: Could not resolve "./app" from "resources/js/index.jsx")*

------
https://chatgpt.com/codex/tasks/task_e_6892456e24b48326a133fd91be31afc3