### PR TITLE
feat: send appointment push notification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,9 @@ FIREBASE_PROJECT_ID=placeholder_project_id
 FIREBASE_PRIVATE_KEY=placeholder_private_key
 FIREBASE_CLIENT_EMAIL=placeholder_client_email
 
+# FCM Configuration
+FCM_SERVER_KEY=placeholder_fcm_server_key
+
 # Frontend Firebase Config
 VITE_FIREBASE_API_KEY=placeholder_api_key
 VITE_FIREBASE_AUTH_DOMAIN=placeholder_auth_domain

--- a/app/Services/PushNotificationService.php
+++ b/app/Services/PushNotificationService.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Appointment;
+use Illuminate\Support\Facades\Http;
+
+class PushNotificationService
+{
+    protected $serverKey;
+
+    public function __construct()
+    {
+        $this->serverKey = config('services.fcm.server_key');
+    }
+
+    public function sendAppointmentNotification(string $token, Appointment $appointment): bool
+    {
+        if (empty($this->serverKey) || empty($token)) {
+            \Log::warning('FCM notification skipped: missing server key or token');
+            return false;
+        }
+
+        $response = Http::withToken($this->serverKey)
+            ->post('https://fcm.googleapis.com/fcm/send', [
+                'to' => $token,
+                'notification' => [
+                    'title' => 'Appointment Booked',
+                    'body' => sprintf(
+                        'Your %s appointment is scheduled for %s.',
+                        $appointment->serviceType->name,
+                        $appointment->start_at->format('M d, Y g:i A')
+                    ),
+                ],
+                'data' => [
+                    'appointment_id' => $appointment->id,
+                    'start_at' => $appointment->start_at->toIso8601String(),
+                    'end_at' => $appointment->end_at->toIso8601String(),
+                ],
+            ]);
+
+        return $response->successful();
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -44,4 +44,8 @@ return [
         'calendar_id' => env('GOOGLE_CALENDAR_ID', 'primary'),
         'service_account_key_path' => env('GOOGLE_SERVICE_ACCOUNT_KEY_PATH'),
     ],
+
+    'fcm' => [
+        'server_key' => env('FCM_SERVER_KEY'),
+    ],
 ];


### PR DESCRIPTION
## Summary
- send FCM push notification when appointment booked
- add FCM server key config and env variable

## Testing
- `composer install --no-interaction` *(fails: ext-sodium missing)*
- `composer install --no-interaction --ignore-platform-req=ext-sodium` *(fails: requires PHP ~8.3)*
- `php -l app/Services/PushNotificationService.php`
- `php -l app/Http/Controllers/Api/AppointmentController.php`
- `php -l config/services.php`


------
https://chatgpt.com/codex/tasks/task_e_6892457928948326a056ba5a7fbfd355