### PR TITLE
Add appointment reminder job and scheduler

### DIFF
--- a/app/Jobs/SendAppointmentReminder.php
+++ b/app/Jobs/SendAppointmentReminder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Appointment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Kreait\Laravel\Firebase\Facades\Firebase;
+use Kreait\Firebase\Messaging\CloudMessage;
+use Kreait\Firebase\Messaging\Notification;
+use Illuminate\Support\Facades\Log;
+
+class SendAppointmentReminder implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public Appointment $appointment)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->appointment->load(['customer', 'serviceType']);
+        $customer = $this->appointment->customer;
+
+        if (!$customer || !$customer->firebase_uid) {
+            Log::warning('Skipping appointment reminder: missing customer or firebase UID', [
+                'appointment_id' => $this->appointment->id,
+            ]);
+            return;
+        }
+
+        try {
+            $messaging = Firebase::messaging();
+
+            $message = CloudMessage::fromArray([
+                // Assumes client subscribes to a topic based on firebase UID
+                'topic' => 'user_' . $customer->firebase_uid,
+                'notification' => [
+                    'title' => 'Appointment Reminder',
+                    'body' => 'Your ' . $this->appointment->serviceType->name . ' appointment starts at ' .
+                        $this->appointment->start_at->format('g:i A'),
+                ],
+                'data' => [
+                    'appointment_id' => (string) $this->appointment->id,
+                    'start_at' => $this->appointment->start_at->toIso8601String(),
+                ],
+            ]);
+
+            $messaging->send($message);
+            Log::info('Appointment reminder sent', ['appointment_id' => $this->appointment->id]);
+        } catch (\Throwable $e) {
+            Log::error('Failed to send appointment reminder', [
+                'appointment_id' => $this->appointment->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SendAppointmentReminder job using Firebase Cloud Messaging
- dispatch reminder job when an appointment transitions to `paid`
- schedule FCM reminders to run every minute for paid appointments starting soon

## Testing
- `composer install --ignore-platform-reqs`
- `./vendor/bin/phpunit` *(fails: 500 status)*

------
https://chatgpt.com/codex/tasks/task_e_6892457b0dd883268162a3644a53bb22